### PR TITLE
Fix for backport of Dell OS10 driver

### DIFF
--- a/ansible/roles/dell-switch/tasks/main.yml
+++ b/ansible/roles/dell-switch/tasks/main.yml
@@ -17,5 +17,5 @@
   local_action:
     module: dellos10_config
     provider: "{{ dell_switch_provider }}"
-    src: "{{ lookup('template', 'dellos10-config.j2') }}"
+    src: dellos10-config.j2
   when: dell_switch_type == 'dellos10'


### PR DESCRIPTION
Resolves the error:
{"changed": false, "msg": "path specified in src not found"}