### PR TITLE
yoga cherries

### DIFF
--- a/ansible/group_vars/all/ipa
+++ b/ansible/group_vars/all/ipa
@@ -19,6 +19,9 @@ ipa_builder_source_url: "https://opendev.org/openstack/ironic-python-agent-build
 # Version of IPA builder source repository. Default is {{ openstack_branch }}.
 ipa_builder_source_version: "{{ openstack_branch }}"
 
+# List of additional build host packages to install.
+ipa_build_dib_host_packages_extra: []
+
 # List of default Diskimage Builder (DIB) elements to use when building IPA
 # images. Default is ["centos", "enable-serial-console",
 # "ironic-python-agent-ramdisk"].

--- a/ansible/group_vars/all/overcloud-dib
+++ b/ansible/group_vars/all/overcloud-dib
@@ -10,6 +10,9 @@
 # is {{ os_distribution == 'rocky' }}. This will change in a future release.
 overcloud_dib_build_host_images: "{{ os_distribution == 'rocky' }}"
 
+# List of additional build host packages to install.
+overcloud_dib_host_packages_extra: []
+
 # List of overcloud host disk images to build. Each element is a dict defining
 # an image in a format accepted by the stackhpc.os-images role. Default is to
 # build an image named "deployment_image" configured with the overcloud_dib_*

--- a/ansible/overcloud-host-image-build.yml
+++ b/ansible/overcloud-host-image-build.yml
@@ -22,6 +22,7 @@
           include_role:
             name: stackhpc.os-images
           vars:
+            os_images_package_dependencies_extra: "{{ overcloud_dib_host_packages_extra | select | list }}"
             os_images_venv: "{{ virtualenv_path }}/overcloud-host-image-dib"
             os_images_package_state: latest
             os_images_upper_constraints_file: "{{ overcloud_dib_upper_constraints_file }}"

--- a/ansible/overcloud-ipa-build.yml
+++ b/ansible/overcloud-ipa-build.yml
@@ -36,6 +36,7 @@
           include_role:
             name: stackhpc.os-images
           vars:
+            os_images_package_dependencies_extra: "{{ ipa_build_dib_host_packages_extra | select | list }}"
             os_images_venv: "{{ virtualenv_path }}/ipa-build-dib"
             os_images_package_state: latest
             os_images_upper_constraints_file: "{{ ipa_build_upper_constraints_file }}"

--- a/ansible/physical-network.yml
+++ b/ansible/physical-network.yml
@@ -27,6 +27,7 @@
       - arista
       - dellos6
       - dellos9
+      - dellos10
       - dell-powerconnect
       - junos
       - mellanox
@@ -111,7 +112,7 @@
       arista_switch_interface_config: "{{ switch_interface_config }}"
 
 - name: Ensure DellOS physical switches are configured
-  hosts: switches_of_type_dellos6:switches_of_type_dellos9:&switches_in_display_mode_False
+  hosts: switches_of_type_dellos6:switches_of_type_dellos9:switches_of_type_dellos10:&switches_in_display_mode_False
   gather_facts: no
   roles:
     - role: ssh-known-host

--- a/ansible/roles/dell-switch/README.md
+++ b/ansible/roles/dell-switch/README.md
@@ -1,10 +1,10 @@
 Dell Switch
 ===========
 
-This role configures Dell switches using the `dellos6` or `dellos9` Ansible
-modules.  It provides a fairly minimal abstraction of the configuration
-interface provided by the `dellos` modules, allowing for application of
-arbitrary switch configuration options.
+This role configures Dell switches using the `dellos6`, `dellos9`, or
+`dellos10` Ansible modules.  It provides a fairly minimal abstraction of the
+configuration interface provided by the `dellos` modules, allowing for
+application of arbitrary switch configuration options.
 
 Requirements
 ------------
@@ -14,7 +14,8 @@ The switches should be configured to allow SSH access.
 Role Variables
 --------------
 
-`dell_switch_type` is the type of Dell switch. One of `dellos6`, `dellos9`.
+`dell_switch_type` is the type of Dell switch. One of `dellos6`, `dellos9`, or
+`dellos10`.
 
 `dell_switch_provider` is authentication provider information passed as the
 `provider` argument to the `dellos` modules.

--- a/ansible/roles/dell-switch/defaults/main.yml
+++ b/ansible/roles/dell-switch/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Type of Dell switch. One of dellos6, dellos9.
+# Type of Dell switch. One of dellos6, dellos9, or dellos10.
 dell_switch_type:
 
 # Authentication provider information.

--- a/ansible/roles/dell-switch/tasks/main.yml
+++ b/ansible/roles/dell-switch/tasks/main.yml
@@ -12,3 +12,10 @@
     provider: "{{ dell_switch_provider }}"
     src: dellos9-config.j2
   when: dell_switch_type == 'dellos9'
+
+- name: Ensure DellOS10 switches are configured
+  local_action:
+    module: dellos10_config
+    provider: "{{ dell_switch_provider }}"
+    src: "{{ lookup('template', 'dellos10-config.j2') }}"
+  when: dell_switch_type == 'dellos10'

--- a/ansible/roles/dell-switch/templates/dellos10-config.j2
+++ b/ansible/roles/dell-switch/templates/dellos10-config.j2
@@ -1,0 +1,16 @@
+#jinja2: trim_blocks: True,lstrip_blocks: True
+
+{% for line in dell_switch_config %}
+{{ line }}
+{% endfor %}
+
+{% for interface, config in dell_switch_interface_config.items() %}
+interface {{ interface }}
+{% if config.description is defined %}
+description {{ config.description }}
+{% endif %}
+{% for line in config.config %}
+{{ line }}
+{% endfor %}
+exit
+{% endfor %}

--- a/ansible/seed-ipa-build.yml
+++ b/ansible/seed-ipa-build.yml
@@ -26,6 +26,7 @@
           include_role:
             name: stackhpc.os-images
           vars:
+            os_images_package_dependencies_extra: "{{ ipa_build_dib_host_packages_extra | select | list }}"
             os_images_venv: "{{ virtualenv_path }}/ipa-build-dib"
             os_images_package_state: latest
             os_images_upper_constraints_file: "{{ ipa_build_upper_constraints_file }}"

--- a/doc/source/configuration/reference/ironic-python-agent.rst
+++ b/doc/source/configuration/reference/ironic-python-agent.rst
@@ -44,6 +44,9 @@ image build``.
     https://opendev.org/openstack/ironic-python-agent-builder
 ``ipa_builder_source_version``
     Version of IPA builder source repository. Default is ``master``.
+``ipa_build_dib_host_packages_extra``
+    List of additional build host packages to install. Default is an empty
+    list.
 ``ipa_build_dib_elements_default``
     List of default Diskimage Builder (DIB) elements to use when building IPA
     images. Default is ``["centos", "enable-serial-console",

--- a/doc/source/configuration/reference/overcloud-dib.rst
+++ b/doc/source/configuration/reference/overcloud-dib.rst
@@ -41,6 +41,8 @@ Linux is used.
 `Cloud-init <https://cloudinit.readthedocs.io/en/latest/>`__ is used to process
 the configuration drive built by Bifrost during provisioning.
 
+``overcloud_dib_host_packages_extra``
+    List of additional host packages to install. Default is an empty list.
 ``overcloud_dib_host_images``
     List of overcloud host disk images to build. Each element is a dict
     defining an image in a format accepted by the `stackhpc.os-images

--- a/doc/source/configuration/reference/physical-network.rst
+++ b/doc/source/configuration/reference/physical-network.rst
@@ -18,6 +18,7 @@ The following switch operating systems are currently supported:
   <https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-44/System-Configuration/Network-Command-Line-Utility-NCLU/>`__)
 * Dell OS 6
 * Dell OS 9
+* Dell OS 10
 * Dell PowerConnect
 * Juniper Junos OS
 * Mellanox MLNX OS
@@ -192,13 +193,13 @@ default connection parameters used by Ansible:
 
 * ``ansible_user`` is the SSH username.
 
-Dell OS6 and OS9
-----------------
+Dell OS6, OS9, and OS10
+-----------------------
 
-Configuration for these devices is applied using the ``dellos6_config`` and
-``dellos9_config`` Ansible modules.
+Configuration for these devices is applied using the ``dellos6_config``,
+``dellos9_config``, and ``dellos10_config`` Ansible modules.
 
-``switch_type`` should be set to ``dellos6`` or ``dellos9``.
+``switch_type`` should be set to ``dellos6``, ``dellos9``, or ``dellos10``.
 
 Provider
 ^^^^^^^^

--- a/etc/kayobe/ipa.yml
+++ b/etc/kayobe/ipa.yml
@@ -19,6 +19,9 @@
 # Version of IPA builder source repository. Default is {{ openstack_branch }}.
 #ipa_builder_source_version:
 
+# List of additional build host packages to install. Default is an empty list.
+#ipa_build_dib_host_packages_extra:
+
 # List of default Diskimage Builder (DIB) elements to use when building IPA
 # images. Default is ["centos", "enable-serial-console",
 # "ironic-python-agent-ramdisk"].

--- a/etc/kayobe/overcloud-dib.yml
+++ b/etc/kayobe/overcloud-dib.yml
@@ -10,6 +10,9 @@
 # is {{ os_distribution == 'rocky' }}. This will change in a future release.
 #overcloud_dib_build_host_images:
 
+# List of additional build host packages to install. Default is an empty list.
+#overcloud_dib_host_packages_extra:
+
 # List of overcloud host disk images to build. Each element is a dict defining
 # an image in a format accepted by the stackhpc.os-images role. Default is to
 # build an image named "deployment_image" configured with the overcloud_dib_*

--- a/releasenotes/notes/dellos10-support-31e209bcdb45552a.yaml
+++ b/releasenotes/notes/dellos10-support-31e209bcdb45552a.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds support for configuring Dell OS10 Switches using the `dellemc.os10
+    Ansible collection <https://galaxy.ansible.com/dellemc/os10>`__. This is
+    integrated with the ``kayobe physical network configure`` command.

--- a/releasenotes/notes/image-build-host-packages-1f1a3cf59436d82b.yaml
+++ b/releasenotes/notes/image-build-host-packages-1f1a3cf59436d82b.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Adds support for installing additional build host dependencies when
+    building IPA and overcloud host images via
+    ``ipa_build_dib_host_packages_extra`` and
+    ``overcloud_dib_host_packages_extra``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML>=3.10.0 # MIT
 selinux # MIT
 # INI parsing
 oslo.config>=5.2.0 # Apache-2.0
+paramiko # LGPL

--- a/requirements.yml
+++ b/requirements.yml
@@ -43,7 +43,7 @@ roles:
   - src: stackhpc.mellanox-switch
     version: v1.0.0
   - src: stackhpc.os-images
-    version: v1.11.0
+    version: v1.15.0
   - src: stackhpc.os-ironic-state
     version: v1.3.1
   - src: stackhpc.os-networks

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,9 @@ collections:
   - name: https://opendev.org/openstack/ansible-collection-kolla
     type: git
     version: stable/yoga
+  - name: dellemc.os10
+    version: 1.1.1
+
 roles:
   - src: ahuffman.resolv
     version: 1.3.1


### PR DESCRIPTION
[xena] fec5b5a1c9 None feat: automatic update of community files stackhpc/xena

  SKIP: created by stackhpc-ci bot

[xena] 1e63dd9aae If7d6e58b19f98ccb7cc4c209e458cb6f4f4765ad Add support for Rocky Linux 8

  SKIP: present on yoga

[xena] a29f10e16a I4857e170ad75d2824701df583d1312b3398b93f4 Update CentOS Stream base image

  SKIP: present on yoga

[xena] 2f16e80cfd Ia8c927c330b9428a3824a6925f6274cbc54314a0 Support elements repositories for overcloud host images

  SKIP: present on yoga

[xena] 5b5df80be7 I366fbe98d27fa70b1aeb398c129f626fe042b5df Support building multiple disk images

  SKIP: present on yoga

[xena] ae2e0ed2fc I7ca7608d36910eb519340641d037dc6601ab5fb2 Fix up unit tests for proxy backport

  KEEP: Use original commit

[xena] 9e89264957 I6424fc405894514a63fb2b641637bbb9d5c070c0 Fix no_proxy configuration

  SKIP: present on yoga

[xena] 90f987fbed I6515d028914e8956eac23662c3714a908fda6ac4 proxy: add ansible issue 8743 workaround

  SKIP: present on yoga

[xena] bec34228ad I37b9d18f0523c121357c5a37ec6fc458209f8e79 Add support for root filesystem UUID customisation

  SKIP: present on yoga

[xena] 769ca36738 Ic5130a7512d4a26354bd292b0ab51ab4a9279f0a Add support for configuring proxy settings

  SKIP: present on yoga

[xena] d5fb949025 I2823016294e7df63f63be9ab26535b3962a71ebe Add support for dellos10 switch configuration

  CHOICE: present on multiple branches

    [master] 1fbb5cb400

[xena] 969bfefd57 I319dd51ed3221826f820fbc0ae3639b89e9c82ea Adds kolla_ansible_venv_ansible

  SKIP: present on yoga

[xena] 6142e31cba Id3972c24022aeb6421494c3cccdc8e7cbce802e6 libvirt: support SASL authentication

  SKIP: present on yoga

[xena] 559716e579 I73fef63fb886a9d543d2f4231fb009523495edb3 libvirt: deploy libvirt on the host

  SKIP: present on yoga

[xena] 82a288f221 I2f6c2f92903815973865ef0f5d6b867d5b995bd5 Add overcloud_dib_upper_constraints_file variable

  SKIP: present on yoga

[xena] c8e26fe32a I350f58c8a82f0f31608b34054e804c5c198d6806 Support for untemplated dirs in kolla config

  SKIP: present on yoga

[xena] a93fe43d87 I2c2378ebd99ac02586518e80e4b86a9d765476e6 Add dependencies for EFI and LVM based overcloud images

  SKIP: present on yoga

[xena] aa98c9c1e5 I93d242889e225b4e60254f6b9cc5eeb457294ac8 Build overcloud host image directly with DIB

  SKIP: present on yoga

[xena] 04133e3142 None feat: automatic update of workflows stackhpc/xena

  SKIP: created by stackhpc-ci bot

Proposed cherries:
git cherry-pick -x 1fbb5cb400  # Add support for dellos10 switch configuration
\# git cherry-pick -x ae2e0ed2fc  # SKIPPED (no longer required) Fix up unit tests for proxy backport