### PR TITLE
Fix ipaddr redirect with dellemc.os10 backport

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,7 @@
 ---
 collections:
+  - name: ansible.netcommon
+    version: <2.6
   - name: dellemc.os10
     version: 1.1.1
 


### PR DESCRIPTION
The dellemc.os10 collection pulls in the latest version of
ansible.netcommon, which has dropped the redirect for the ipaddr filter.
This breaks use of the filter without an FQCN.

This change pins the version of ansible.netcommon to <2.6, to ensure the
redirect remains.