### PR TITLE
Add support for specifying SNAT source and destination filters

### DIFF
--- a/ansible/roles/snat/tasks/main.yml
+++ b/ansible/roles/snat/tasks/main.yml
@@ -15,5 +15,10 @@
     out_interface: "{{ item.interface }}"
     jump: SNAT
     to_source: "{{ item.source_ip }}"
+    destination: "{{ item.destination | default(omit) }}"
+    destination_port: "{{ item.destination_port | default(omit) }}"
+    destination_ports: "{{ item.destination_ports | default(omit) }}"
+    source: "{{ item.source | default(omit) }}"
+    source_port: "{{ item.source_port | default(omit) }}"
   with_items: "{{ snat_rules }}"
   become: True

--- a/releasenotes/notes/snat-rules-dst-src-14ce6ca6bec26086.yaml
+++ b/releasenotes/notes/snat-rules-dst-src-14ce6ca6bec26086.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds support for specifying SNAT source and destination filters. This is
+    useful if forwarded packets need to exit on a different interface depending
+    on the source or destination IP address or port.


### PR DESCRIPTION
This is useful if forwarded packets need to exit on a different
interface depending on the source or destination IP address or port.

Change-Id: Ifbfbade4baaa1901b08549e52acc725e45379a16
(cherry picked from commit 3903ca92e92288e026d5923ab9a7c4d65d2e2d4a)