### PR TITLE
Install fork of ansible with Rocky 8 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pbr>=2.0 # Apache-2.0
-ansible>=2.9.0,<2.11.0,!=2.9.8,!=2.9.12 # GPLv3
+ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky # GPLv3
 Jinja2<3.1.0 # BSD
 cliff>=3.1.0 # Apache
 netaddr!=0.7.16,>=0.7.13 # BSD

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pbr>=2.0 # Apache-2.0
+ansible>=2.9.0,<2.11.0,!=2.9.8,!=2.9.12 # GPLv3
 ansible-base@git+https://github.com/stackhpc/ansible@stackhpc/2.10/rocky # GPLv3
 Jinja2<3.1.0 # BSD
 cliff>=3.1.0 # Apache


### PR DESCRIPTION
This means we would support Rocky 8 out of the box. Otherwise, we need to install the ansible fork as another step. I'm trying to avoid this in the stackhpc AIO scenario to keep it simple.