### PR TITLE
Infra VMs: fix some playbook host patterns

### DIFF
--- a/ansible/kayobe-ansible-user.yml
+++ b/ansible/kayobe-ansible-user.yml
@@ -86,7 +86,7 @@
       become: True
 
 - name: Verify that the Kayobe Ansible user account is accessible
-  hosts: seed-hypervisor:seed:overcloud
+  hosts: seed-hypervisor:seed:overcloud:infra-vms
   gather_facts: false
   tags:
     - kayobe-ansible-user

--- a/ansible/network-connectivity.yml
+++ b/ansible/network-connectivity.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check network connectivity between hosts
-  hosts: seed:seed-hypervisor:overcloud
+  hosts: seed:seed-hypervisor:overcloud:infra-vms
   vars:
     # Set this to an external IP address to check.
     nc_external_ip: 8.8.8.8

--- a/ansible/wipe-disks.yml
+++ b/ansible/wipe-disks.yml
@@ -8,7 +8,7 @@
 # also closed and removed from crypttab.
 
 - name: Ensure that all unmounted block devices are wiped
-  hosts: seed-hypervisor:seed:overcloud
+  hosts: seed-hypervisor:seed:overcloud:infra-vms
   tags:
     - wipe-disks
   roles:


### PR DESCRIPTION
The infra-vms group was not added to some playbook host patterns where it should have been. This change fixes that.

TrivialFix

Change-Id: I5df2918035df7577627fd2bd68417beddbcbf848 (cherry picked from commit 5e9affb62c40a885f4d64b0dbcc4bf6576b8779c)