### PR TITLE
Add prometheus-libvirt-exporter back to inventory

### DIFF
--- a/ansible/roles/kolla-ansible/templates/overcloud-services.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-services.j2
@@ -520,6 +520,9 @@ elasticsearch
 [prometheus-blackbox-exporter:children]
 monitoring
 
+[prometheus-libvirt-exporter:children]
+compute
+
 [prometheus-msteams:children]
 prometheus-alertmanager
 


### PR DESCRIPTION
It got lost in a merge conflict.

Change-Id: I4d2cf0fc4983aad1cf20c717e040aa773834aced
