### PR TITLE
Run handlers before configuring veth interfaces

### DIFF
--- a/ansible/roles/network-redhat/tasks/main.yml
+++ b/ansible/roles/network-redhat/tasks/main.yml
@@ -39,6 +39,10 @@
     interfaces_setup_filter: "{{ kayobe_ansible_setup_filter }}"
     interfaces_setup_gather_subset: "{{ kayobe_ansible_setup_gather_subset }}"
 
+# NOTE(priteau): We need to run handlers from MichaelRigart.interfaces before
+# we start configuring any veth interfaces.
+- meta: flush_handlers
+
 # Configure virtual ethernet patch links to connect the workload provision
 # and external network bridges to the Neutron OVS bridge.
 - name: Ensure OVS patch links exist


### PR DESCRIPTION
Handlers from MichaelRigart.interfaces are not run until the end of the play, which results in the veth role trying to create veth interfaces against a non-existing bridge.

Change-Id: Ie1c9e1ada50774cbcaec528bd64d8df066c21d2e