### PR TITLE
Fix Ansible version specifier

### DIFF
--- a/ansible/roles/kolla-ansible/defaults/main.yml
+++ b/ansible/roles/kolla-ansible/defaults/main.yml
@@ -24,7 +24,7 @@ kolla_ansible_venv_extra_requirements: []
 # Pip requirement specifier for the ansible package. NOTE: This limits the
 # version of ansible used by kolla-ansible to avoid new releases from breaking
 # tested code. Changes to this limit should be tested.
-kolla_ansible_venv_ansible: 'ansible>=4,<6.0'
+kolla_ansible_venv_ansible: 'ansible>=2.10.0,<5.0'
 
 # Virtualenv directory where Kolla-ansible's ansible modules will execute
 # remotely on the target nodes. If None, no virtualenv will be used.


### PR DESCRIPTION
Change I319dd51ed3221826f820fbc0ae3639b89e9c82ea was backported from stable/yoga without updating the Ansible requirement specifier. This results in the following error:

    ERROR: Ansible version should be between 2.10 and 2.11. Current version is 2.12.10 which is not supported.