### PR TITLE
Correct name of role mrlesmithjr.manage_lvm

### DIFF
--- a/ansible/lvm.yml
+++ b/ansible/lvm.yml
@@ -27,7 +27,7 @@
       vars:
         manage_lvm: True
       include_role:
-        name: mrlesmithjr.manage-lvm
+        name: mrlesmithjr.manage_lvm
         apply:
           become: True
       when:

--- a/requirements.yml
+++ b/requirements.yml
@@ -20,7 +20,7 @@ roles:
     version: v1.14.0
   - src: mrlesmithjr.chrony
     version: v0.1.4
-  - src: mrlesmithjr.manage-lvm
+  - src: mrlesmithjr.manage_lvm
     version: v0.2.8
   - src: mrlesmithjr.mdadm
     version: v0.1.1


### PR DESCRIPTION
The role name was changes yesterday to use an underscore instead of a hyphen. This corrects `requirements.yml` so that bootstraps can find the role on Ansible Galazy again.