### PR TITLE
Correct name for role mrlesmithjr.manage_lvm

### DIFF
--- a/ansible/group_vars/all/compute
+++ b/ansible/group_vars/all/compute
@@ -70,15 +70,15 @@ compute_luks_devices: []
 ###############################################################################
 # Compute node LVM configuration.
 
-# List of compute volume groups. See mrlesmithjr.manage-lvm role for
+# List of compute volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 compute_lvm_groups: "{{ compute_lvm_groups_default + compute_lvm_groups_extra }}"
 
-# Default list of compute volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of compute volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 compute_lvm_groups_default: "{{ [compute_lvm_group_data] if compute_lvm_group_data_enabled | bool else [] }}"
 
-# Additional list of compute volume groups. See mrlesmithjr.manage-lvm role
+# Additional list of compute volume groups. See mrlesmithjr.manage_lvm role
 # for format.
 compute_lvm_groups_extra: []
 
@@ -89,7 +89,7 @@ compute_lvm_groups_extra: []
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 compute_lvm_group_data_enabled: "{{ docker_storage_driver == 'devicemapper' }}"
 
-# Compute LVM volume group for data. See mrlesmithjr.manage-lvm role for
+# Compute LVM volume group for data. See mrlesmithjr.manage_lvm role for
 # format.
 compute_lvm_group_data:
   vgname: data

--- a/ansible/group_vars/all/controllers
+++ b/ansible/group_vars/all/controllers
@@ -92,15 +92,15 @@ controller_luks_devices: []
 ###############################################################################
 # Controller node LVM configuration.
 
-# List of controller volume groups. See mrlesmithjr.manage-lvm role for
+# List of controller volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 controller_lvm_groups: "{{ controller_lvm_groups_default + controller_lvm_groups_extra }}"
 
-# Default list of controller volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of controller volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 controller_lvm_groups_default: "{{ [controller_lvm_group_data] if controller_lvm_group_data_enabled | bool else [] }}"
 
-# Additional list of controller volume groups. See mrlesmithjr.manage-lvm role
+# Additional list of controller volume groups. See mrlesmithjr.manage_lvm role
 # for format.
 controller_lvm_groups_extra: []
 
@@ -111,7 +111,7 @@ controller_lvm_groups_extra: []
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 controller_lvm_group_data_enabled: "{{ docker_storage_driver == 'devicemapper' }}"
 
-# Controller LVM volume group for data. See mrlesmithjr.manage-lvm role for
+# Controller LVM volume group for data. See mrlesmithjr.manage_lvm role for
 # format.
 controller_lvm_group_data:
   vgname: data

--- a/ansible/group_vars/all/monitoring
+++ b/ansible/group_vars/all/monitoring
@@ -70,15 +70,15 @@ monitoring_luks_devices: []
 ###############################################################################
 # Monitoring node LVM configuration.
 
-# List of monitoring node volume groups. See mrlesmithjr.manage-lvm role for
+# List of monitoring node volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 monitoring_lvm_groups: "{{ monitoring_lvm_groups_default + monitoring_lvm_groups_extra }}"
 
-# Default list of monitoring node volume groups. See mrlesmithjr.manage-lvm
+# Default list of monitoring node volume groups. See mrlesmithjr.manage_lvm
 # role for format.
 monitoring_lvm_groups_default: "{{ controller_lvm_groups_default }}"
 
-# Additional list of monitoring node volume groups. See mrlesmithjr.manage-lvm
+# Additional list of monitoring node volume groups. See mrlesmithjr.manage_lvm
 # role for format.
 monitoring_lvm_groups_extra: "{{ controller_lvm_groups_extra }}"
 

--- a/ansible/group_vars/all/seed
+++ b/ansible/group_vars/all/seed
@@ -38,14 +38,14 @@ seed_luks_devices: []
 ###############################################################################
 # Seed node LVM configuration.
 
-# List of seed volume groups. See mrlesmithjr.manage-lvm role for format.
+# List of seed volume groups. See mrlesmithjr.manage_lvm role for format.
 seed_lvm_groups: "{{ seed_lvm_groups_default + seed_lvm_groups_extra }}"
 
-# Default list of seed volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of seed volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 seed_lvm_groups_default: "{{ [seed_lvm_group_data] if seed_lvm_group_data_enabled | bool else [] }}"
 
-# Additional list of seed volume groups. See mrlesmithjr.manage-lvm role for
+# Additional list of seed volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 seed_lvm_groups_extra: []
 
@@ -56,7 +56,7 @@ seed_lvm_groups_extra: []
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 seed_lvm_group_data_enabled: "{{ docker_storage_driver == 'devicemapper' }}"
 
-# Seed LVM volume group for data. See mrlesmithjr.manage-lvm role for format.
+# Seed LVM volume group for data. See mrlesmithjr.manage_lvm role for format.
 seed_lvm_group_data:
   vgname: data
   disks: "{{ seed_lvm_group_data_disks }}"

--- a/ansible/group_vars/all/seed-hypervisor
+++ b/ansible/group_vars/all/seed-hypervisor
@@ -35,7 +35,7 @@ seed_hypervisor_luks_devices: []
 ###############################################################################
 # Seed hypervisor node LVM configuration.
 
-# List of seed hypervisor volume groups. See mrlesmithjr.manage-lvm role for
+# List of seed hypervisor volume groups. See mrlesmithjr.manage_lvm role for
 # format. Set to "{{ seed_hypervisor_lvm_groups_with_data }}" to create a
 # volume group for libvirt storage.
 seed_hypervisor_lvm_groups: []
@@ -44,7 +44,7 @@ seed_hypervisor_lvm_groups: []
 seed_hypervisor_lvm_groups_with_data:
   - "{{ seed_hypervisor_lvm_group_data }}"
 
-# Seed LVM volume group for data. See mrlesmithjr.manage-lvm role for format.
+# Seed LVM volume group for data. See mrlesmithjr.manage_lvm role for format.
 seed_hypervisor_lvm_group_data:
   vgname: data
   disks: "{{ seed_hypervisor_lvm_group_data_disks }}"

--- a/ansible/group_vars/all/storage
+++ b/ansible/group_vars/all/storage
@@ -82,15 +82,15 @@ storage_luks_devices: []
 ###############################################################################
 # Storage node LVM configuration.
 
-# List of storage volume groups. See mrlesmithjr.manage-lvm role for
+# List of storage volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 storage_lvm_groups: "{{ storage_lvm_groups_default + storage_lvm_groups_extra }}"
 
-# Default list of storage volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of storage volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 storage_lvm_groups_default: "{{ [storage_lvm_group_data] if storage_lvm_group_data_enabled | bool else [] }}"
 
-# Additional list of storage volume groups. See mrlesmithjr.manage-lvm role
+# Additional list of storage volume groups. See mrlesmithjr.manage_lvm role
 # for format.
 storage_lvm_groups_extra: []
 
@@ -101,7 +101,7 @@ storage_lvm_groups_extra: []
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 storage_lvm_group_data_enabled: "{{ docker_storage_driver == 'devicemapper' }}"
 
-# Storage LVM volume group for data. See mrlesmithjr.manage-lvm role for
+# Storage LVM volume group for data. See mrlesmithjr.manage_lvm role for
 # format.
 storage_lvm_group_data:
   vgname: data

--- a/ansible/lvm.yml
+++ b/ansible/lvm.yml
@@ -27,7 +27,7 @@
       vars:
         manage_lvm: True
       include_role:
-        name: mrlesmithjr.manage-lvm
+        name: mrlesmithjr.manage_lvm
         apply:
           become: True
       when:

--- a/doc/source/configuration/reference/hosts.rst
+++ b/doc/source/configuration/reference/hosts.rst
@@ -640,8 +640,8 @@ this is mapped to the following variables:
 * ``storage_lvm_groups``
 
 The format of these variables is as defined by the ``lvm_groups`` variable of
-the `mrlesmithjr.manage-lvm
-<https://galaxy.ansible.com/mrlesmithjr/manage-lvm>`__ Ansible role.
+the `mrlesmithjr.manage_lvm
+<https://galaxy.ansible.com/mrlesmithjr/manage_lvm>`__ Ansible role.
 
 LVM for libvirt
 ---------------

--- a/doc/source/control-plane-service-placement.rst
+++ b/doc/source/control-plane-service-placement.rst
@@ -60,8 +60,8 @@ hosts in the ``monitoring`` group.
    ``bootstrap_user``     Username with which to access the host before
                           ``ansible_user`` is configured.
    ``lvm_groups``         List of LVM volume groups to configure.  See
-                          `mrlesmithjr.manage-lvm role
-                          <https://galaxy.ansible.com/mrlesmithjr/manage-lvm/>`_
+                          `mrlesmithjr.manage_lvm role
+                          <https://galaxy.ansible.com/mrlesmithjr/manage_lvm/>`_
                           for format.
    ``mdadm_arrays``       List of software RAID arrays. See `mrlesmithjr.mdadm
                           role

--- a/etc/kayobe/compute.yml
+++ b/etc/kayobe/compute.yml
@@ -63,15 +63,15 @@
 ###############################################################################
 # Compute node LVM configuration.
 
-# List of compute volume groups. See mrlesmithjr.manage-lvm role for
+# List of compute volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #compute_lvm_groups:
 
-# Default list of compute volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of compute volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #compute_lvm_groups_default:
 
-# Additional list of compute volume groups. See mrlesmithjr.manage-lvm role
+# Additional list of compute volume groups. See mrlesmithjr.manage_lvm role
 # for format.
 #compute_lvm_groups_extra:
 
@@ -82,7 +82,7 @@
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 #compute_lvm_group_data_enabled:
 
-# Compute LVM volume group for data. See mrlesmithjr.manage-lvm role for
+# Compute LVM volume group for data. See mrlesmithjr.manage_lvm role for
 # format.
 #compute_lvm_group_data:
 

--- a/etc/kayobe/controllers.yml
+++ b/etc/kayobe/controllers.yml
@@ -72,15 +72,15 @@
 ###############################################################################
 # Controller node LVM configuration.
 
-# List of controller volume groups. See mrlesmithjr.manage-lvm role for
+# List of controller volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #controller_lvm_groups:
 
-# Default list of controller volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of controller volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #controller_lvm_groups_default:
 
-# Additional list of controller volume groups. See mrlesmithjr.manage-lvm role
+# Additional list of controller volume groups. See mrlesmithjr.manage_lvm role
 # for format.
 #controller_lvm_groups_extra:
 
@@ -91,7 +91,7 @@
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 #controller_lvm_group_data_enabled:
 
-# Controller LVM volume group for data. See mrlesmithjr.manage-lvm role for
+# Controller LVM volume group for data. See mrlesmithjr.manage_lvm role for
 # format.
 #controller_lvm_group_data:
 

--- a/etc/kayobe/monitoring.yml
+++ b/etc/kayobe/monitoring.yml
@@ -63,15 +63,15 @@
 ###############################################################################
 # Monitoring node LVM configuration.
 
-# List of monitoring node volume groups. See mrlesmithjr.manage-lvm role for
+# List of monitoring node volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #monitoring_lvm_groups:
 
-# Default list of monitoring node volume groups. See mrlesmithjr.manage-lvm
+# Default list of monitoring node volume groups. See mrlesmithjr.manage_lvm
 # role for format.
 #monitoring_lvm_groups_default:
 
-# Additional list of monitoring node volume groups. See mrlesmithjr.manage-lvm
+# Additional list of monitoring node volume groups. See mrlesmithjr.manage_lvm
 # role for format.
 #monitoring_lvm_groups_extra:
 

--- a/etc/kayobe/seed-hypervisor.yml
+++ b/etc/kayobe/seed-hypervisor.yml
@@ -33,7 +33,7 @@
 ###############################################################################
 # Seed hypervisor node LVM configuration.
 
-# List of seed hypervisor volume groups. See mrlesmithjr.manage-lvm role for
+# List of seed hypervisor volume groups. See mrlesmithjr.manage_lvm role for
 # format. Set to "{{ seed_hypervisor_lvm_groups_with_data }}" to create a
 # volume group for libvirt storage.
 #seed_hypervisor_lvm_groups:
@@ -42,7 +42,7 @@
 # default.
 #seed_hypervisor_lvm_groups_with_data:
 
-# Seed LVM volume group for data. See mrlesmithjr.manage-lvm role for format.
+# Seed LVM volume group for data. See mrlesmithjr.manage_lvm role for format.
 #seed_hypervisor_lvm_group_data:
 
 # List of disks for use by seed hypervisor LVM data volume group. Default to an

--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -33,14 +33,14 @@
 ###############################################################################
 # Seed node LVM configuration.
 
-# List of seed volume groups. See mrlesmithjr.manage-lvm role for format.
+# List of seed volume groups. See mrlesmithjr.manage_lvm role for format.
 #seed_lvm_groups:
 
-# Default list of seed volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of seed volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #seed_lvm_groups_default:
 
-# Additional list of seed volume groups. See mrlesmithjr.manage-lvm role for
+# Additional list of seed volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #seed_lvm_groups_extra:
 
@@ -51,7 +51,7 @@
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 #seed_lvm_group_data_enabled:
 
-# Seed LVM volume group for data. See mrlesmithjr.manage-lvm role for format.
+# Seed LVM volume group for data. See mrlesmithjr.manage_lvm role for format.
 #seed_lvm_group_data:
 
 # List of disks for use by seed LVM data volume group. Default to an invalid

--- a/etc/kayobe/storage.yml
+++ b/etc/kayobe/storage.yml
@@ -68,15 +68,15 @@
 ###############################################################################
 # Storage node LVM configuration.
 
-# List of storage volume groups. See mrlesmithjr.manage-lvm role for
+# List of storage volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #storage_lvm_groups:
 
-# Default list of storage volume groups. See mrlesmithjr.manage-lvm role for
+# Default list of storage volume groups. See mrlesmithjr.manage_lvm role for
 # format.
 #storage_lvm_groups_default:
 
-# Additional list of storage volume groups. See mrlesmithjr.manage-lvm role
+# Additional list of storage volume groups. See mrlesmithjr.manage_lvm role
 # for format.
 #storage_lvm_groups_extra:
 
@@ -87,7 +87,7 @@
 # 'docker_storage_driver' is set to 'devicemapper', or false otherwise.
 #storage_lvm_group_data_enabled:
 
-# Storage LVM volume group for data. See mrlesmithjr.manage-lvm role for
+# Storage LVM volume group for data. See mrlesmithjr.manage_lvm role for
 # format.
 #storage_lvm_group_data:
 

--- a/releasenotes/notes/correct-name-of-mrlesmithjr-manage_lvm-role-c34e217446c19a57.yaml
+++ b/releasenotes/notes/correct-name-of-mrlesmithjr-manage_lvm-role-c34e217446c19a57.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes download of roles from Ansible Galaxy following the renaming of the
+    ``mrlesmithjr.manage_lvm`` role.
+    `LP#2023502 <https://bugs.launchpad.net/kolla-ansible/+bug/2024163>`__

--- a/requirements.yml
+++ b/requirements.yml
@@ -11,7 +11,7 @@ roles:
   version: v1.12.0
 - src: mrlesmithjr.chrony
   version: v0.1.4
-- src: mrlesmithjr.manage-lvm
+- src: mrlesmithjr.manage_lvm
   version: v0.2.6
 - src: mrlesmithjr.mdadm
   version: v0.1.1

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -11,7 +11,7 @@
         - kayobe-tox-ansible
         - kayobe-tox-molecule
         - kayobe-overcloud-centos8s
-        - kayobe-overcloud-ubuntu-focal
+        # - kayobe-overcloud-ubuntu-focal Note(mattcrees): Job temporarily disabled until fix is merged, see: https://review.opendev.org/c/openstack/kolla/+/885857
         - kayobe-overcloud-tls-centos8s
         - kayobe-overcloud-host-configure-centos8s
         - kayobe-overcloud-host-configure-ubuntu-focal
@@ -29,7 +29,7 @@
         - kayobe-tox-ansible
         - kayobe-tox-molecule
         - kayobe-overcloud-centos8s
-        - kayobe-overcloud-ubuntu-focal
+        # - kayobe-overcloud-ubuntu-focal Note(mattcrees): Job temporarily disabled until fix is merged, see: https://review.opendev.org/c/openstack/kolla/+/885857
         - kayobe-overcloud-tls-centos8s
         - kayobe-overcloud-host-configure-centos8s
         - kayobe-overcloud-host-configure-ubuntu-focal


### PR DESCRIPTION
The name of ``mrlesmithjr.manage_lvm`` was changed yesterday in release v0.2.10 to use an underscore, instead of a hyphen. As this changes the name of the role on Ansible Galaxy, it needs to be updated in ``requirements.yml``.

Closes-Bug: #2024163
Change-Id: I4ea8d8c3a822a7c217bcfcfd5027eecfd21beaed