### PR TITLE
Fix issue with control host bootstrap

### DIFF
--- a/releasenotes/notes/fix-galaxy-install-netcommon-ac82c77c2877e6b6.yaml
+++ b/releasenotes/notes/fix-galaxy-install-netcommon-ac82c77c2877e6b6.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes an issue installing the ansible.netcommon collection during
+    control host bootstrap/upgrade. This was due to a recent change
+    in the galaxy API. See bug
+    `LP#2038088 <https://bugs.launchpad.net/kayobe/+bug/2038088`__.
+    for more details.

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,8 @@
 ---
 collections:
+  - name: ansible.netcommon
+    source: https://old-galaxy.ansible.com
+    version: '>=1.0.0,<3.0.0'
   - name: dellemc.os10
     version: 1.1.1
 


### PR DESCRIPTION
Due to the changes in the galaxy API, we saw the following error:

```
ERROR! Unexpected Exception, this is probably a bug: '/api/v3/plugin/ansible/content/published/collections/index/ansible/netcommon/versions/'
to see the full traceback, use -vvv
Failed to install Ansible collections from /home/stack/rav/cl5/venvs/kayobe/share/kayobe/requirements.yml via Ansible Galaxy: returncode 250
```

This is because netcommon is pulled in as a dependency of the dellemc.os10 collection. Explitly install the collection using the old API is a workaround for the issue. The constaints are taken from galaxy.yml in the dellemc.os10 collection. The constraint was >=1.0.0 but it later versions is constrained to <3.0.0.

Change-Id: I45e9f50a7306a5647702788ec5c19d0c7933e685
Partial-Bug: 2038088