### PR TITLE
Stop kolla fighting with kayobe over selinux state

### DIFF
--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -91,13 +91,6 @@
         kolla_ansible_passwords_path: "{{ kayobe_env_config_path }}/kolla/passwords.yml"
         kolla_overcloud_group_vars_path: "{{ kayobe_env_config_path }}/kolla/inventory/group_vars"
         kolla_ansible_certificates_path: "{{ kayobe_env_config_path }}/kolla/certificates"
-        # NOTE: This differs from the default SELinux mode in kolla ansible,
-        # which is permissive. The justification for using this mode is twofold:
-        # 1. it avoids filling up the audit log
-        # 2. it avoids an issue seen when using diskimage-builder in the bifrost
-        # container.
-        # We could look at making the SELinux mode configurable in future.
-        kolla_selinux_state: disabled
         kolla_inspector_dhcp_pool_start: "{{ inspection_net_name | net_inspection_allocation_pool_start }}"
         kolla_inspector_dhcp_pool_end: "{{ inspection_net_name | net_inspection_allocation_pool_end }}"
         kolla_inspector_netmask: "{{ inspection_net_name | net_mask }}"

--- a/ansible/roles/kolla-ansible/templates/kolla/globals.yml
+++ b/ansible/roles/kolla-ansible/templates/kolla/globals.yml
@@ -550,9 +550,7 @@ grafana_admin_username: "{{ grafana_local_admin_user_name }}"
 # Bootstrap-servers - Host Configuration
 #########################################
 
-{% if kolla_selinux_state is not none %}
-selinux_state: {{ kolla_selinux_state }}
-{% endif %}
+change_selinux: false
 
 {% if kolla_enable_host_ntp is not none %}
 enable_host_ntp: {{ kolla_enable_host_ntp | bool }}

--- a/ansible/roles/selinux/defaults/main.yml
+++ b/ansible/roles/selinux/defaults/main.yml
@@ -3,7 +3,7 @@
 selinux_policy: targeted
 
 # Target SELinux state
-selinux_state: disabled
+selinux_state: "{{ kolla_selinux_state | default('disabled') }}"
 
 # Whether to reboot to apply SELinux config changes.
 disable_selinux_do_reboot: true


### PR DESCRIPTION
I found kolla-ansible was setting selinux policy to disabled so after host configure and reboot you always hit:

```
TASK [selinux : Abort SELinux configuration because reboot is disabled] ***************************************************************************************************************************************************************
Friday 01 December 2023  11:16:10 +0100 (0:00:01.314)       0:00:48.063 *******                                                                                                                                                        
fatal: [cpt07]: FAILED! => changed=false                                                                                                                                                                                               
  msg: |-                                                                                                                                                                                                                              
    SELinux state change requires a reboot, but selinux_do_reboot is false. Please run again with selinux_do_reboot set to true to reboot.                                                                                             
```
   
on the next host configure,


Change-Id: I0bfcb36224c403b04d04d51b4faad188a1dd2cac