### PR TITLE
Disable configuration of SELinux by Kolla Ansible

### DIFF
--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -91,13 +91,6 @@
         kolla_ansible_passwords_path: "{{ kayobe_env_config_path }}/kolla/passwords.yml"
         kolla_overcloud_group_vars_path: "{{ kayobe_env_config_path }}/kolla/inventory/group_vars"
         kolla_ansible_certificates_path: "{{ kayobe_env_config_path }}/kolla/certificates"
-        # NOTE: This differs from the default SELinux mode in kolla ansible,
-        # which is permissive. The justification for using this mode is twofold:
-        # 1. it avoids filling up the audit log
-        # 2. it avoids an issue seen when using diskimage-builder in the bifrost
-        # container.
-        # We could look at making the SELinux mode configurable in future.
-        kolla_selinux_state: disabled
         kolla_inspector_dhcp_pool_start: "{{ inspection_net_name | net_inspection_allocation_pool_start }}"
         kolla_inspector_dhcp_pool_end: "{{ inspection_net_name | net_inspection_allocation_pool_end }}"
         kolla_inspector_netmask: "{{ inspection_net_name | net_mask }}"

--- a/ansible/roles/kolla-ansible/defaults/main.yml
+++ b/ansible/roles/kolla-ansible/defaults/main.yml
@@ -279,12 +279,6 @@ kolla_external_tls_cert:
 kolla_internal_tls_cert:
 
 ###############################################################################
-# SELinux
-
-# Desired SELinux state.
-kolla_selinux_state:
-
-###############################################################################
 # NTP
 
 # Whether to enable the NTP daemon.

--- a/ansible/roles/kolla-ansible/templates/kolla/globals.yml
+++ b/ansible/roles/kolla-ansible/templates/kolla/globals.yml
@@ -550,9 +550,9 @@ grafana_admin_username: "{{ grafana_local_admin_user_name }}"
 # Bootstrap-servers - Host Configuration
 #########################################
 
-{% if kolla_selinux_state is not none %}
-selinux_state: {{ kolla_selinux_state }}
-{% endif %}
+# Kayobe performs configuration of SELinux, so there is no need for Kolla
+# Ansible to repeat this.
+change_selinux: false
 
 {% if kolla_enable_host_ntp is not none %}
 enable_host_ntp: {{ kolla_enable_host_ntp | bool }}

--- a/releasenotes/notes/disable-kolla-selinux-71f76e63776e0aed.yaml
+++ b/releasenotes/notes/disable-kolla-selinux-71f76e63776e0aed.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Disables configuration of SELinux by Kolla Ansible, which could revert
+    configuration set by Kayobe.


### PR DESCRIPTION
When using the default configuration, bootstrapping servers with Kolla Ansible would revert SELinux from permissive to disabled.

Change-Id: I8ad027384d9d062fdd363b10fd7bcebe22d775e0 (cherry picked from commit 22307eb73e97833c25521fda5ff8fc6f173116ad)