### PR TITLE
Deduplicate before picking merge strategy

### DIFF
--- a/ansible/roles/kolla-openstack/action_plugins/kolla_custom_config_info.py
+++ b/ansible/roles/kolla-openstack/action_plugins/kolla_custom_config_info.py
@@ -128,13 +128,13 @@ class ConfigCollector(object):
             if not os.path.exists(dirname):
                 missing_directories.add(dirname)
 
+            sources = map(os.path.realpath, sources)
+            sources = _dedup(sources)
+
             rule = self._find_matching_rule(relative_path, sources)
 
             if not rule:
                 continue
-
-            sources = map(os.path.realpath, sources)
-            sources = _dedup(sources)
 
             if rule["strategy"] == 'copy':
                 copy = {


### PR DESCRIPTION
I missed this when I refactored the code to fallback to templating. We need to deduplicate before picking the strategy for the fallback to work for symlinked files.

Change-Id: Iddd6c90a6daa41e1d1cdaa6b598491792c13394d Closes-Bug: #2042689
(cherry picked from commit 786a78d074a4451cf2774b2e8e4c0808816beff2)