### PR TITLE
Pin ansible-core to 2.14.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pbr>=2.0 # Apache-2.0
 Jinja2>3 # BSD
 ansible>=6,<8.0 # GPLv3
+ansible-core<2.14.12 # GPLv3
 cliff>=3.1.0 # Apache
 netaddr!=0.7.16,>=0.7.13 # BSD
 PyYAML>=3.10.0 # MIT


### PR DESCRIPTION
Pin ansible-core to 2.14.11 to avoid AnsibleUnsafeText bug seen in 2.14.12.

Traceback as seen on AIO:

```
Traceback (most recent call last):
  File "/home/cloud-user/venvs/kayobe/lib64/python3.9/site-packages/ansible/executor/task_executor.py", line 158, in run
    res = self._execute()
  File "/home/cloud-user/venvs/kayobe/lib64/python3.9/site-packages/ansible/executor/task_executor.py", line 633, in _execute
    result = self._handler.run(task_vars=vars_copy)
  File "/home/cloud-user/venvs/kayobe/share/kayobe/ansible/roles/kolla-openstack/action_plugins/kolla_custom_config_info.py", line 242, in run
    collector.collect()
  File "/home/cloud-user/venvs/kayobe/share/kayobe/ansible/roles/kolla-openstack/action_plugins/kolla_custom_config_info.py", line 194, in collect
    self._collect_destination(item)
  File "/home/cloud-user/venvs/kayobe/share/kayobe/ansible/roles/kolla-openstack/action_plugins/kolla_custom_config_info.py", line 213, in _collect_destination
    files = glob.glob(abs_glob, flags=glob.GLOBSTAR)
  File "/home/cloud-user/venvs/kayobe/lib64/python3.9/site-packages/wcmatch/glob.py", line 876, in glob
    return list(iglob(patterns, flags=flags, root_dir=root_dir, dir_fd=dir_fd, limit=limit, exclude=exclude))
  File "/home/cloud-user/venvs/kayobe/lib64/python3.9/site-packages/wcmatch/glob.py", line 862, in iglob
    yield from Glob(patterns, flags, root_dir, dir_fd, limit, exclude).glob()
  File "/home/cloud-user/venvs/kayobe/lib64/python3.9/site-packages/wcmatch/glob.py", line 455, in __init__
    raise TypeError(
TypeError: Pattern and root_dir should be of the same type, not <class 'ansible.utils.unsafe_proxy.AnsibleUnsafeText'> and <class 'str'>
fatal: [localhost]: FAILED! => 
  msg: 'Unexpected failure during module execution: Pattern and root_dir should be of the same type, not <class ''ansible.utils.unsafe_proxy.AnsibleUnsafeText''> and <class ''str''>'
  stdout: ''
```