### PR TITLE
Adds support for using Dell OS 10 switches with NGS

### DIFF
--- a/ansible/kolla-openstack.yml
+++ b/ansible/kolla-openstack.yml
@@ -94,6 +94,7 @@
     switch_type_to_device_type:
       arista: netmiko_arista_eos
       dellos9: netmiko_dell_force10
+      dellos10: netmiko_dell_os10
       dell-powerconnect: netmiko_dell_powerconnect
       junos: netmiko_juniper
       openvswitch: netmiko_ovs_linux

--- a/releasenotes/notes/dellos10-support-ngs-24ba50803b4bf528.yaml
+++ b/releasenotes/notes/dellos10-support-ngs-24ba50803b4bf528.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds support for using DellOS 10 switches with Networking Generic Switch.


### PR DESCRIPTION
Support for Dell OS 10 was added in Networking Generic Switch in the 2023.1 release[1].

[1] https://review.opendev.org/c/openstack/networking-generic-switch/+/860067

Change-Id: Id3cd5e081dd5c40897ddaada65cfb184d56345b6 (cherry picked from commit 47fb2ae32a35fe3f177fff5d9212a3945dc4334f)