### PR TITLE
Change condition of neutron agent container image regex

### DIFF
--- a/ansible/group_vars/all/kolla
+++ b/ansible/group_vars/all/kolla
@@ -207,7 +207,7 @@ overcloud_container_image_regex_map:
     enabled: "{{ kolla_enable_neutron | bool }}"
   # Neutron SFC agent not currently supported on CentOS binary builds.
   - regex: "neutron-\\(dhcp\\|l3\\|linuxbridge\\|openvswitch\\)-agent"
-    enabled: "{{ kolla_enable_neutron | bool and not kolla_enable_ovn | bool}}"
+    enabled: "{{ kolla_enable_neutron_ovs | default(kolla_enable_neutron | bool and not kolla_enable_ovn | bool) }}"
   - regex: neutron-mlnx-agent
     enabled: "{{ kolla_enable_neutron_mlnx | bool }}"
   - regex: neutron-sriov-agent

--- a/ansible/group_vars/all/kolla
+++ b/ansible/group_vars/all/kolla
@@ -207,7 +207,7 @@ overcloud_container_image_regex_map:
     enabled: "{{ kolla_enable_neutron | bool }}"
   # Neutron SFC agent not currently supported on CentOS binary builds.
   - regex: "neutron-\\(dhcp\\|l3\\|linuxbridge\\|openvswitch\\)-agent"
-    enabled: "{{ kolla_enable_neutron_ovs | default(kolla_enable_neutron | bool and not kolla_enable_ovn | bool) }}"
+    enabled: "{{ kolla_build_neutron_ovs | default(kolla_enable_neutron | bool and not kolla_enable_ovn | bool) }}"
   - regex: neutron-mlnx-agent
     enabled: "{{ kolla_enable_neutron_mlnx | bool }}"
   - regex: neutron-sriov-agent


### PR DESCRIPTION
Add variable kolla_enable_neutron_ovs to make enabling both ovn and ovs possible.
Retain old condition as default value to ensure regex mapping works normally when kolla_enable_neutron_ovs is not given.