### PR TITLE
Fix ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 collections:
   - name: https://opendev.org/openstack/ansible-collection-kolla
     type: git
-    version: stable/yoga
+    version: unmaintained/yoga
   - name: ansible.netcommon
     source: https://old-galaxy.ansible.com
     version: '>=1.0.0,<3.0.0'


### PR DESCRIPTION
The stable/yoga branch for ansible-collection-kolla no longer exists. This change corrects the reference in requirements.yml to unmaintained/yoga

