### PR TITLE
Support setting whether an Apt repo is trusted

### DIFF
--- a/ansible/roles/apt/templates/kayobe.sources.j2
+++ b/ansible/roles/apt/templates/kayobe.sources.j2
@@ -11,5 +11,8 @@ Signed-by: {{ apt_keys_path }}/{{ repo.signed_by }}
 {% if repo.architecture is defined %}
 Architecture: {{ repo.architecture }}
 {% endif %}
+{% if repo.trusted is defined %}
+Trusted: {{ repo.trusted | bool }}
+{% endif %}
 
 {% endfor %}

--- a/doc/source/configuration/reference/hosts.rst
+++ b/doc/source/configuration/reference/hosts.rst
@@ -376,6 +376,7 @@ items:
   ``apt_keys_path`` (optional, default is unset)
 * ``architecture``: whitespace-separated list of architectures that will be used
   (optional, default is unset)
+* ``trusted``: boolean value (optional, default is unset)
 
 The default of ``apt_repositories`` is an empty list.
 

--- a/releasenotes/notes/apt-configure-trust-for-repos-e2d379b5f5a4ec30.yaml
+++ b/releasenotes/notes/apt-configure-trust-for-repos-e2d379b5f5a4ec30.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds support for setting whether an Apt repo is trusted.


### PR DESCRIPTION
Useful if you're configuring your own private repos, and don't/can't sign them.

Change-Id: I2d592c5479530b2fe9a60c14ee59e817b8402490