### PR TITLE
Adds support for using Cumulus switches (NVUE) with NGS

### DIFF
--- a/ansible/kolla-openstack.yml
+++ b/ansible/kolla-openstack.yml
@@ -99,6 +99,7 @@
       junos: netmiko_juniper
       openvswitch: netmiko_ovs_linux
       nclu: netmiko_cumulus
+      nvue: netmiko_cumulus_nvue
     ipa_image_name: "ipa"
   pre_tasks:
     - block:


### PR DESCRIPTION
NVUE was added downstream in 2023.1 [1].

[1] https://github.com/stackhpc/networking-generic-switch/commit/b56cca8dd5b2872a8d07c6c5cdf58b4244a07456