### PR TITLE
Revert "nvue: Use StackHPC fork"

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -13,10 +13,8 @@ collections:
     version: 1.0.0
   - name: stackhpc.openstack
     version: 0.2.2
-# NOTE(mnasiadka): Use nvue collection fork until https://gitlab.com/nvidia-networking/systems-engineering/nvue/-/merge_requests/26 is merged
-  - name: https://github.com/stackhpc/ansible-nvidia-nvue.git
-    type: git
-    version: stackhpc
+  - name: nvidia.nvue
+    version: 1.2.0
 
 roles:
   - src: ahuffman.resolv


### PR DESCRIPTION
This reverts commit aa60ba1a1479492fe8928445b6a00b1a81c1da5a.

1.2.6 with patches from our fork has been released