### PR TITLE
Revert "nvue: Use StackHPC fork"

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -7,10 +7,8 @@ collections:
     version: 1.1.1
   - name: stackhpc.linux
     version: 1.1.0
-# NOTE(mnasiadka): Use nvue collection fork until https://gitlab.com/nvidia-networking/systems-engineering/nvue/-/merge_requests/26 is merged
-  - name: https://github.com/stackhpc/ansible-nvidia-nvue.git
-    type: git
-    version: stackhpc
+  - name: nvidia.nvue
+    version: 1.2.0
 
 roles:
   - src: ahuffman.resolv


### PR DESCRIPTION
This reverts commit cdce40fb480fa3a8b71a13f459bc69da28c4f456.

1.2.6 with patches from our fork has been released