### PR TITLE
Support IPA download with authenticated requests

### DIFF
--- a/ansible/roles/image-download/defaults/main.yml
+++ b/ansible/roles/image-download/defaults/main.yml
@@ -21,3 +21,23 @@ image_download_dest:
 # Host from which to fetch the image.
 # Only used when image_download_path is set.
 image_download_host: "{{ inventory_hostname }}"
+
+# Username for Digest, Basic or WSSE authentication. Default is unset, in which
+# case the parameter is omitted.
+image_download_url_username:
+
+# Password for Digest, Basic or WSSE authentication. Default is unset, in which
+# case the parameter is omitted.
+image_download_url_password:
+
+# Force sending the Basic authentication header upon initial request. Useful if
+# the remote endpoint does not respond with HTTP 401 to the initial
+# unauthenticated request. Must be a boolean. Default is unset, in which case
+# the parameter is omitted.
+image_download_force_basic_auth:
+
+# List of header names that will not be sent on subsequent redirected requests.
+# Set to ['Authorization'] if being redirected from an authenticated endpoint
+# to an unauthenticated endpoint. Default is unset, in which case the parameter
+# is omitted.
+image_download_unredirected_headers:

--- a/ansible/roles/image-download/tasks/main.yml
+++ b/ansible/roles/image-download/tasks/main.yml
@@ -15,6 +15,10 @@
           uri:
             url: "{{ image_download_checksum_url }}"
             return_content: true
+            url_username: "{{ image_download_url_username or omit }}"
+            url_password: "{{ image_download_url_password or omit }}"
+            force_basic_auth: "{{ image_download_force_basic_auth or omit }}"
+            unredirected_headers: "{{ image_download_unredirected_headers or omit }}"
           register: expected_checksum
           until: expected_checksum is successful
           retries: 3
@@ -35,6 +39,10 @@
         # Always download the image if we have no checksum to compare with.
         force: "{{ expected_checksum is skipped }}"
         backup: true
+        url_username: "{{ image_download_url_username or omit }}"
+        url_password: "{{ image_download_url_password or omit }}"
+        force_basic_auth: "{{ image_download_force_basic_auth or omit }}"
+        unredirected_headers: "{{ image_download_unredirected_headers or omit }}"
       register: result
       until: result is successful
       retries: 3

--- a/releasenotes/notes/image-download-auth-e9fd02b71e26dd52.yaml
+++ b/releasenotes/notes/image-download-auth-e9fd02b71e26dd52.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Adds variables to configure authentication parameters in the
+    ``image-download`` role, which is used to download IPA images. The new
+    variables are ``image_download_url_username``,
+    ``image_download_url_password``, ``image_download_force_basic_auth`` and
+    ``image_download_unredirected_headers``. See documentation of the `get_url
+    <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html>`__
+    and `uri
+    <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html>`__
+    Ansible modules for more details on how to use these variables.


### PR DESCRIPTION
This commit adds variables to configure authentication parameters in the image-download role, which is used to download IPA images.

The new variables are image_download_url_username, image_download_url_password, image_download_force_basic_auth and image_download_unredirected_headers.

See Ansible documentation for more details about these variables [1,2].

[1] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html
[2] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html

Change-Id: Ib149e97d42ca46b96b5c05030ba2cf871a63cde9