### PR TITLE
Add ovn-sb-db-relay Ansible group in overcloud

### DIFF
--- a/ansible/roles/kolla-ansible/templates/overcloud-services.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-services.j2
@@ -453,6 +453,9 @@ ovn-database
 [ovn-sb-db:children]
 ovn-database
 
+[ovn-sb-db-relay:children]
+ovn-database
+
 [venus-api:children]
 venus
 


### PR DESCRIPTION
Depends-On: https://github.com/stackhpc/kolla-ansible/pull/675
Change-Id: I794a62841aa84d3a576f376bd0cfd3ae47b1f77a