### PR TITLE
Fix network configure on Rocky hosts

### DIFF
--- a/releasenotes/notes/fix-rocky-network-templating-d16606de0ea28d2d.yaml
+++ b/releasenotes/notes/fix-rocky-network-templating-d16606de0ea28d2d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Bumps MichaelRigart.interfaces to fix an issue where ``kayobe overcloud
+    host configure`` would fail to template during the networking tasks on
+    Rocky hosts, with the error ``Could not load "ipaddr"``.
+    `LP#2107335 <https://bugs.launchpad.net/kayobe/+bug/2107335>`__

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,7 +17,7 @@ roles:
     # There are no versioned releases of this role.
     version: 29871bf3279ef95fc8f7339b9abd13f869980750
   - src: MichaelRigart.interfaces
-    version: v1.14.4
+    version: v1.15.5
   - src: mrlesmithjr.chrony
     version: v0.1.4
   - src: mrlesmithjr.manage_lvm


### PR DESCRIPTION
When evaluating the templates, an error is raised failing to load ipaddr. Fix this by bumping the version of MichaelRigart.interfaces.

```
ansible.errors.AnsibleError: template error while templating string: Could not load "ipaddr": 'ipaddr'.
```

Closes-Bug: #2107335
Change-Id: I17a94a7367c57b37fa01db737f0235472360155a