### PR TITLE
Add redfish_address variable and support discovering it

### DIFF
--- a/ansible/inventory/group_vars/all/bmc
+++ b/ansible/inventory/group_vars/all/bmc
@@ -13,3 +13,6 @@ ipmi_username:
 
 # Password to use to access a host's BMC via IPMI.
 ipmi_password:
+
+# Address to use to access a host's BMC via Redfish.
+redfish_address:

--- a/ansible/overcloud-inventory-discover.yml
+++ b/ansible/overcloud-inventory-discover.yml
@@ -46,9 +46,10 @@
                 and host not in ignore_hosts %}
           {% set hostvars=ironic_inventory._meta.hostvars[host] %}
           {% set ipmi_address=hostvars.driver_info.ipmi_address | default %}
+          {% set redfish_address=hostvars.driver_info.redfish_address | default %}
           {% set system_vendor=hostvars.extra.system_vendor | default %}
           {% set bmc_type=system_vendor | bmc_type_from_system_vendor %}
-          {{ host }} ipmi_address={{ ipmi_address }} bmc_type={{ bmc_type }}
+          {{ host }} {% if redfish_address %}redfish_address={{ redfish_address }} {% elif ipmi_address %}ipmi_address={{ ipmi_address }} {% endif %}bmc_type={{ bmc_type }}
           {% endif %}
           {% endfor %}
 

--- a/etc/kayobe/bmc.yml
+++ b/etc/kayobe/bmc.yml
@@ -14,6 +14,9 @@
 # Password to use to access a host's BMC via IPMI.
 #ipmi_password:
 
+# Address to use to access a host's BMC via Redfish.
+#redfish_address:
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/releasenotes/notes/discover-redfish-address-6517d8a03d8c1a37.yaml
+++ b/releasenotes/notes/discover-redfish-address-6517d8a03d8c1a37.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds a new ``redfish_address`` variable and extends the ``kayobe overcloud
+    inventory discover`` command to discover the address from the Bifrost node
+    inventory.


### PR DESCRIPTION
During the ``kayobe overcloud inventory discover`` command, Kayobe queries the Bifrost ironic node list and updates the Kayobe inventory. If the nodes have a driver_info.ipmi_address field set, an ipmi_address variable will be defined in the Kayobe inventory for the host.

This does not work for Redfish based hosts, which use driver_info.redfish_address in the Ironic node. This change adds a new ``redfish_address`` variable and extends the command to discover the address from the Bifrost node inventory.

Change-Id: Ieb1e61ddadb542732739d1f478b1e5a176e0ac88