### PR TITLE
Move nvidia.nvue to 1.2.9 for cumulus 5.13

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -8,7 +8,7 @@ collections:
   - name: dellemc.os10
     version: 1.1.1
   - name: nvidia.nvue
-    version: 1.2.6
+    version: 1.2.9
   - name: openstack.cloud
     version: '<3'
   - name: stackhpc.linux


### PR DESCRIPTION
Changed switch config started creating errors on cumulus 5.13 onwards.
Bumping the collection version to bring in this fix:
https://gitlab.com/nvidia-networking/systems-engineering/nvue/-/commit/adfc6829ee0fadbcd5273a7635f26d6a79b44eab

Change-Id: Ib92ae8807a5f22090d3025ff93d279004e686870

I have proposed this upstream here:
https://review.opendev.org/c/openstack/kayobe/+/960153