### PR TITLE
2023.1: Switch Kolla collection to EOL tag

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 collections:
   - name: https://opendev.org/openstack/ansible-collection-kolla
     type: git
-    version: unmaintained/2023.1
+    version: 2023.1-eol
   - name: dellemc.os10
     version: 1.1.1
   - name: stackhpc.linux


### PR DESCRIPTION
This could be useful for sites still dealing with upgrades.