### PR TITLE
Bump stackhpc.linux collection to v1.5.1

### DIFF
--- a/releasenotes/notes/bump-stackhpc-linux-v1.5.1-c002b7c99921cd20.yaml
+++ b/releasenotes/notes/bump-stackhpc-linux-v1.5.1-c002b7c99921cd20.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Bumps ``stackhpc.linux`` Ansible collection to v1.5.1. This adds
+    support for configuring MIG devices without creating vGPUs.
+fixes:
+  - |
+    Bumps ``stackhpc.linux`` Ansible collection to v1.5.1. This fixes
+    race conditions in setup of vGPU SR-IOV devices.

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@ collections:
   - name: openstack.cloud
     version: '<3'
   - name: stackhpc.linux
-    version: 1.3.4
+    version: 1.5.1
   - name: stackhpc.network
     version: 1.0.0
   - name: stackhpc.openstack


### PR DESCRIPTION
Fixes race conditions in setup of vGPU SR-IOV devices. Adds support for configuring MIG devices without creating vGPUs.

Change-Id: Ida4b38b98ab1140d44941355bc7ff991b0b5aa47

(cherry picked from commit 0115b6ea5efa9a8ee0583b50f948ee1758960a67)