### PR TITLE
Add support for url sources in kolla_sources (2025.1)

### DIFF
--- a/ansible/roles/kolla-build/templates/kolla/kolla-build.conf
+++ b/ansible/roles/kolla-build/templates/kolla/kolla-build.conf
@@ -40,6 +40,13 @@ location = {{ source_def.location }}
 # Reference of source for {{ source_name }}.
 reference = {{ source_def.reference }}
 {% endif %}
+{% if source_def.sha256 is defined %}
+{# generates sha256 = amd64:xxx,arm64:yyy #}
+sha256 = {{ source_def.sha256.keys() | zip (source_def.sha256.values()) | map("join", ":") | join(",") }}
+{% endif %}
+{% if source_def.version is defined %}
+version = {{ source_def.version }}
+{% endif %}
 
 {% endfor %}
 

--- a/doc/source/configuration/reference/kolla.rst
+++ b/doc/source/configuration/reference/kolla.rst
@@ -247,7 +247,7 @@ default is to specify the URL and version of Bifrost, as defined in
 ``${KAYOBE_CONFIG_PATH}/bifrost.yml``.
 
 For example, to specify a custom source location for the ``ironic-base``
-package:
+package and a custom version of cadvisor:
 
 .. code-block:: yaml
    :caption: ``kolla.yml``
@@ -261,6 +261,11 @@ package:
        type: "git"
        location: https://git.example.com/ironic
        reference: downstream
+     prometheus-cadvisor:
+       version: "0.54.1"
+       sha256:
+         amd64: xxxx
+         arm64: yyyy
 
 This will result in Kayobe adding the following configuration to
 ``kolla-build.conf``:
@@ -278,8 +283,16 @@ This will result in Kayobe adding the following configuration to
    location = https://git.example.com/ironic
    reference = downstream
 
+   [prometheus-cadvisor]
+   version = 0.54.1
+   sha256 = amd64:xxxx,arm64:yyyy
+
 Note that it is currently necessary to include the Bifrost source location if
 using a seed.
+
+Note that it is not necessary to specify the prometheus-cadvisor ``type: url``
+and ``location: https://github.com/...`` because they are inherited from kolla
+(``kolla/common/sources.py``).
 
 Plugins & additions
 -------------------

--- a/releasenotes/notes/override-kolla_sources-url-b268b5c87b051ea0.yaml
+++ b/releasenotes/notes/override-kolla_sources-url-b268b5c87b051ea0.yaml
@@ -1,0 +1,7 @@
+---
+feature:
+  - |
+    Adds support for ``url`` sources in ``kolla_sources``. Previously the
+    ``version`` and ``sha256`` attributes would not be generated in
+    ``kolla-build.conf``, preventing the override for sources with ``url``
+    type. Only ``git`` and ``local`` types worked.


### PR DESCRIPTION
Previously the version and sha256 attributes would not be generated in kolla-build.conf, preventing the override for sources with url type. Only git and local types worked.

Change-Id: I0a5100347d8755a452d2744a458b3177e41196ca

(cherry picked from commit ca230c71c9642586c2aea27f70111e6888095aa4)