### PR TITLE
Move nvidia.nvue to 1.2.9 for cumulus 5.13

### DIFF
--- a/releasenotes/notes/fixes-cumulus-5.13-74e0d08675404f46.yaml
+++ b/releasenotes/notes/fixes-cumulus-5.13-74e0d08675404f46.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Bumps version of ``nvidia.nvue`` Ansible collection from ``1.2.6`` to
+    ``1.2.9``.  This fixes an issue where switch configuration could not be
+    applied to switches running Cumulus Linux 5.13. See `LP#2131677
+    <https://bugs.launchpad.net/kayobe/+bug/2131677>`__ for more details.

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,7 +6,7 @@ collections:
   - name: dellemc.os10
     version: 1.1.1
   - name: nvidia.nvue
-    version: 1.2.6
+    version: 1.2.9
   - name: openstack.cloud
     version: '<3'
   - name: stackhpc.linux


### PR DESCRIPTION
Changed switch config started creating errors on cumulus 5.13 onwards. Bumping the collection version to bring in this fix:

https://gitlab.com/nvidia-networking/systems-engineering/nvue/-/commit/adfc6829ee0fadbcd5273a7635f26d6a79b44eab

Change-Id: Ib92ae8807a5f22090d3025ff93d279004e686870
Closes-Bug: #2131677

(cherry picked from commit 85a0356cbab068026ab03214a7dac7629dca294e)