### PR TITLE
Add loop control to custom DNF repos

### DIFF
--- a/ansible/roles/dnf/tasks/custom-repo.yml
+++ b/ansible/roles/dnf/tasks/custom-repo.yml
@@ -26,6 +26,8 @@
     username: "{{ item.value.username | default(omit) }}"
     state: "{{ item.value.state | default(omit)}}"
   with_dict: "{{ dnf_custom_repos }}"
+  loop_control:
+    label: "{{ item.key }}"
   register: register_dnf_command
   retries: 3
   delay: 10

--- a/releasenotes/notes/dnf-loop-control-6e2c8ba1915d2631.yaml
+++ b/releasenotes/notes/dnf-loop-control-6e2c8ba1915d2631.yaml
@@ -1,0 +1,11 @@
+---
+security:
+  - |
+    Avoid leaking DNF repository username/password credentials in the Kayobe
+    output by adding loop control to print only the repository key.
+    `LP#2087938 <https://launchpad.net/bugs/2087938>`__
+fixes:
+  - |
+    Avoid leaking DNF repository username/password credentials in the Kayobe
+    output by adding loop control to print only the repository key.
+    `LP#2087938 <https://launchpad.net/bugs/2087938>`__


### PR DESCRIPTION
This avoids leaking repository credentials by suppressing the dict output to only print the key.