### PR TITLE
Use github.com instead of opendev.org

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
-  - name: https://opendev.org/openstack/ansible-collection-kolla
+  - name: https://github.com/openstack/ansible-collection-kolla
     type: git
     version: stable/2025.1
   - name: community.docker


### PR DESCRIPTION
This is to avoid failures due to opendev.org downtime.