### PR TITLE
Use github.com instead of opendev.org - cherry pick from 2025.1

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
-  - name: https://opendev.org/openstack/ansible-collection-kolla
+  - name: https://github.com/openstack/ansible-collection-kolla
     type: git
     version: stable/2026.1
   - name: community.docker


### PR DESCRIPTION
This is to avoid failures due to opendev.org downtime.

Change-Id: Idbf131715b29e3d72748432f922bcb818cd48072