### PR TITLE
Add custom_etc_hosts_entries variable

### DIFF
--- a/ansible/roles/etc-hosts/defaults/main.yml
+++ b/ansible/roles/etc-hosts/defaults/main.yml
@@ -4,3 +4,8 @@ customize_etc_hosts: true
 
 # List of hosts to add to /etc/hosts.
 etc_hosts_hosts: "{{ groups['overcloud'] }}"
+
+# Dictionary of custom /etc/hosts entries.
+# Each key is added as a hostname,
+# Each value is added as an IP.
+custom_etc_hosts_entries: {}

--- a/ansible/roles/etc-hosts/tasks/etc-hosts.yml
+++ b/ansible/roles/etc-hosts/tasks/etc-hosts.yml
@@ -31,6 +31,9 @@
         {{ hostvars[host].internal_net_name | net_ip(inventory_hostname=host) }} {{ hostnames | unique | join(' ') }}
         {% endif %}
         {% endfor %}
+        {% for item in custom_etc_hosts_entries | dict2items %}
+        {{ item.value }} {{ item.key }}
+        {% endfor %}
   become: True
   when:
     # Skip hosts that do not have a valid internal network interface.

--- a/doc/source/configuration/reference/hosts.rst
+++ b/doc/source/configuration/reference/hosts.rst
@@ -1453,6 +1453,15 @@ follows:
 
    etc_hosts_gather_facts: false
 
+Custom entries can be added to the ``custom_etc_hosts_entries`` dictionary.
+Each key is treated as a hostname and each value is the IP, for example:
+
+.. code-block:: yaml
+
+   custom_etc_hosts_entries:
+     foo.exaple.com: 1.2.3.4
+     bar.exaple.com: 5.6.7.8
+
 Installing packages required by Kolla Ansible
 =============================================
 *tags:*

--- a/playbooks/kayobe-overcloud-host-configure-base/overrides.yml.j2
+++ b/playbooks/kayobe-overcloud-host-configure-base/overrides.yml.j2
@@ -252,3 +252,7 @@ controller_swap:
 
 # Generate a password for libvirt SASL authentication.
 compute_libvirt_sasl_password: "{% raw %}{{ lookup('password', '/tmp/libvirt-sasl-password') }}{% endraw %}"
+
+# Add a custom entry to /etc/hosts.
+custom_etc_hosts_entries:
+  foo.example.com: 127.0.0.88

--- a/playbooks/kayobe-overcloud-host-configure-base/tests/test_overcloud_host_configure.py
+++ b/playbooks/kayobe-overcloud-host-configure-base/tests/test_overcloud_host_configure.py
@@ -398,3 +398,10 @@ def test_swap(host):
     assert len(swapon) > 1
     swap_devs = [swap.split()[0] for swap in swapon[1:]]
     assert "/swapfile" in swap_devs
+
+
+def test_etc_hosts(host):
+    hosts_entries = host.check_output("cat /etc/hosts")
+    assert "127.0.0.88 foo.example.com" in hosts_entries
+    ping_result = host.check_output("ping -c 1 foo.example.com")
+    assert "1 received" in ping_result

--- a/releasenotes/notes/custom-etc-hosts-f85fcff9aac727aa.yaml
+++ b/releasenotes/notes/custom-etc-hosts-f85fcff9aac727aa.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added a new variable, ``custom_etc_hosts_entries``, for appending entries
+    to ``/etc/hosts``. This is a generic mechanism which, unlike
+    ``etc_hosts_hosts``, can be used to add hosts outside of the Kayobe
+    inventory. ``custom_etc_hosts_entries`` is a dictionary, where each key is
+    a hostname and each value is an IP.


### PR DESCRIPTION
``custom_etc_hosts_entries`` is a new variable which provides a generic way to add entries to ``/etc/hosts``. It differs from ``etc_hosts_hosts`` because it is empty by default and can be used to add hosts that are not in the Kayobe inventory.

``custom_etc_hosts_entries`` is a dictionary where each key is a hostname and each value is an IP address.

Change-Id: I74c8234f77115d6a478559a53ad86534eb12e5f4

(cherry picked from commit 6fb103fd5dec1a7782af2a440c47df3b3c110fdc)